### PR TITLE
Allow fully custom query

### DIFF
--- a/BasicObject.php
+++ b/BasicObject.php
@@ -816,7 +816,7 @@ abstract class BasicObject {
 	 * When using manual query the caller must ensure all fields are present in
 	 * the query (e.g. using `SELECT *`).
 	 */
-	public static function selection_execute($data, $debug=false){
+	protected static function selection_execute($data, $debug=false){
 		global $db;
 
 		$cache_string = null;

--- a/BasicObject.php
+++ b/BasicObject.php
@@ -801,8 +801,23 @@ abstract class BasicObject {
 	 * @returns Array An array of Objects.
 	 */
 	public static function selection($params = array(), $debug=false){
-		global $db;
 		$data = self::build_query($params, '*');
+		return static::selection_execute($data, $debug);
+	}
+
+	/**
+	 * Run a query and build result array. Normally you would use `selection` or
+	 * `from_field` but for advanced usage the query can be prepared manually.
+	 *
+	 * $data must be an array either like:
+	 * - [$query]
+	 * - [$query, $types, $params...]
+	 *
+	 * When using manual query the caller must ensure all fields are present in
+	 * the query (e.g. using `SELECT *`).
+	 */
+	public static function selection_execute($data, $debug=false){
+		global $db;
 
 		$cache_string = null;
 		if(BasicObject::$_enable_cache) {


### PR DESCRIPTION
While rudimentary grouping and joining is possible with `BasicObject::selection` there are many cases where it just isn't possible to generate the needed SQL. For instance joining the table with itself needs table aliases which BO doesn't add. Grouping in general isn't BOs strong side but using a `HAVING` condition is just not possible.

This change allows for using a fully customized query (grouping, joining, etc) while still creating instances of your BO model similar to how `BasicObject::selection` does.

```php
static public function myCustomSelection(){
  return static::selection_execute([
    'SELECT * FROM `my_table` ...'
  ]);
}
```

It assumes the user know what he is doing (i.e. not selecting all the required fields it considered a programming error by the caller).