### PR TITLE
Support passing extra fields to update_attributes

### DIFF
--- a/BasicObject.php
+++ b/BasicObject.php
@@ -1124,13 +1124,15 @@ abstract class BasicObject {
 	 *            permit: Array with keys to permit to update.
 	 *            create: If true new objects can be created if ID is missing or null, otherwise null
 	 *                    will be returned when the object should've been created.
+	 *            extra_fields Array with extra fields to set on the object (using __set)
 	 */
-	public static function update_attributes($array, $options=array()) {
+	public static function update_attributes(array $array, $options=[]) {
 		$defaults = array(
 			'empty_to_null' => true,
 			'commit' => false,
 			'permit' => false,
 			'create' => true,
+			'extra_fields' => [],
 		);
 		$options = array_merge($defaults, $options);
 		if ( $options['empty_to_null'] == true || is_array($options['empty_to_null']) ){
@@ -1174,6 +1176,12 @@ abstract class BasicObject {
 			$obj->_exists = true; //Mark as existing
 		} else if ( $options['create'] === false ){
 			return null;
+		}
+
+		foreach ( $options['extra_fields'] as $key ){
+			if ( array_key_exists($key, $array) ){
+				$obj->$key = $array[$key];
+			}
 		}
 
 		if(!isset($options["commit"]) || $options["commit"] == true) {

--- a/tests/models/ModelExtraFields.php
+++ b/tests/models/ModelExtraFields.php
@@ -1,0 +1,31 @@
+<?php
+
+class ModelExtraFields extends BasicObject {
+	protected static function table_name() {
+		return 'model1';
+	}
+
+	protected static function extra_fields() {
+		return ['int2'];
+	}
+
+	public function __get($key) {
+		switch ( $key ){
+			case 'int2':
+				return $this->int1 - 10;
+				break;
+			default:
+				return parent::__get($key);
+		}
+	}
+
+	public function __set($key, $value) {
+		switch ( $key ){
+			case 'int2':
+				$this->int1 = $value + 10;
+				break;
+			default:
+				parent::__set($key, $value);
+		}
+	}
+};

--- a/tests/suites/BasicObject/ExtraFieldsTest.php
+++ b/tests/suites/BasicObject/ExtraFieldsTest.php
@@ -1,0 +1,37 @@
+<?php
+
+class ExtraFieldsTest extends DatabaseTestCase {
+	public function testSetCalled() {
+		$data = ['int2' => 5];
+		$model = ModelExtraFields::update_attributes($data, [
+			'commit' => false,
+		]);
+		$this->assertEquals(15, $model->int1, 'int1 should be set via int2');
+	}
+
+	public function testOrder() {
+		$data = ['int1' => 4, 'int2' => 5];
+		$model = ModelExtraFields::update_attributes($data, [
+			'commit' => false,
+		]);
+		$this->assertEquals(15, $model->int1, 'base fields should be set before extra fields');
+	}
+
+	public function testPermitNegative() {
+		$data = ['int1' => 4, 'int2' => 5];
+		$model = ModelExtraFields::update_attributes($data, [
+			'commit' => false,
+			'permit' => ['int1'],
+		]);
+		$this->assertEquals(4, $model->int1, 'int2 should be ignored if not listed in permit');
+	}
+
+	public function testPermitPositive() {
+		$data = ['int1' => 4, 'int2' => 5];
+		$model = ModelExtraFields::update_attributes($data, [
+			'commit' => false,
+			'permit' => ['int2'],
+		]);
+		$this->assertEquals(15, $model->int1, 'int2 should be used when listed in permit');
+	}
+}

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -3,9 +3,14 @@
 set +e
 cd `dirname $0`
 
-echo -e "Running tests without cache\n"
+echo "Running tests without cache"
+echo
 ./phpunit --bootstrap "no_cache.php" --exclude-group cache $@
 
-echo -e "\n----------------------\n"
-echo -e "Running tests with cache\n"
+echo
+echo "----------------------"
+echo
+echo "Running tests with cache"
+echo
+
 ./phpunit --bootstrap "with_cache.php" $@

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set +e
+set -e
 cd `dirname $0`
 
 echo "Running tests without cache"


### PR DESCRIPTION
## Problem

Given a class such as this:

``` php
class MyModel extends BasicObject {
  public function __get($key){
    switch($key){
      case 'bar':
        return $this->foo - 12;
      default:
        return parent::__get($key);
      }
  }

  public function __set($key, $value){
    switch($key){
      case 'bar':
        $this->foo = $value + 12;
        break;
      default:
        return parent::__get($key);
  }
}
```

It would be tempting (and useful) to pass `bar` directly to `update_attributes`:

``` php
$data = ['bar' => 1234, ...];
$model = MyModel::update_attributes($data);
```

Since BO only allows setting values existing in database columns other values are silently ignored (which is probably a good thing).
## Workaround

``` php
$data = [...];
$model = MyModel::update_attributes($data, ['commit' => false]);
$model->foo = $data['bar']; // ignoring error-checking, e.g. array_key_exists
$model->commit();
```
## Solution

``` php
$data = ['bar' => 1234, ...];
$model = MyModel::update_attributes($data, ['extra_fields' => 'bar']);
```
## Questions
- Should `extra_fields` populate `permit` array too? As of now one must set both both when using `permit`.
